### PR TITLE
Switch from deprecated node-uuid to uuid

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,11 +35,11 @@
     "morgan": "^1.7.0",
     "multer": "^1.1.0",
     "node-ffprobe": "^1.2.2",
-    "node-uuid": "^1.4.7",
     "redis": "^2.4.2",
     "rimraf": "^2.5.0",
     "smartquotes": "^1.0.0",
     "underscore": "^1.8.3",
+    "uuid": "^3.0.1",
     "webaudio-peaks": "0.0.5",
     "winston": "^2.2.0"
   },

--- a/server/index.js
+++ b/server/index.js
@@ -3,7 +3,7 @@ var express = require("express"),
     compression = require("compression"),
     path = require("path"),
     multer = require("multer"),
-    uuid = require("node-uuid"),
+    uuid = require("uuid"),
     mkdirp = require("mkdirp");
 
 // Routes and middleware


### PR DESCRIPTION
Hi from [CPBN](http://cpbn.org)/[WNPR](http://wnpr.org) in CT :-)

This PR fixes this warning on `npm install`:

```
npm WARN deprecated node-uuid@1.4.7: use uuid module instead
```
