### PR TITLE
Lock d3 version to last supported version for app

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "browserify": "^13.0.0",
     "canvas": "git+https://github.com/chearon/node-canvas.git#12971f64a66b",
     "compression": "^1.6.1",
-    "d3": "^4.1.1",
+    "d3": "4.10.0",
     "dotenv": "^2.0.0",
     "express": "^4.13.3",
     "jquery": "^2.2.1",


### PR DESCRIPTION
Fixes the syntax error upon server startup mentioned in: https://github.com/nypublicradio/audiogram/issues/95